### PR TITLE
[PLATFORM-425]: [prima_datadog] Reconsider `noop` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [Next]
+
+## [0.2.0]
+
+### Changed
+
+- `Datadog::new` removed `is_reporting_enabled` parameter
+
+### Fixed
+
+- Linting on `from_addr` function for `clippy::wrong_self_convention` check.
+
+
+[Next]: https://github.com/primait/prima_datadog.rs/compare/0.2.0...HEAD
+[0.2.0]: https://github.com/primait/prima_datadog.rs/compare/0.1.9...0.2.0
+[0.1.9]: https://github.com/primait/prima_datadog.rs/compare/0.1.7...0.1.9
+[0.1.7]: https://github.com/primait/prima_datadog.rs/compare/0.1.6...0.1.7
+[0.1.6]: https://github.com/primait/prima_datadog.rs/compare/0.1.5...0.1.6
+[0.1.5]: https://github.com/primait/prima_datadog.rs/releases/tag/0.1.5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,6 @@ license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[features]
-noop = []
-
 [dependencies]
 dogstatsd = "0.7"
 once_cell = "1.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prima_datadog"
-version = "0.1.9"
+version = "0.2.0"
 edition = "2018"
 description = "An opinionated library to share code and approach to Datadog logging in prima.it"
 license = "MIT"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -15,11 +15,6 @@ args = [
 [tasks.test]
 command = "cargo"
 args = ["test"]
-dependencies = ["build", "test-noop"]
-
-[tasks.test-noop]
-command = "cargo"
-args = ["test", "--features", "noop"]
 
 [tasks.lint]
 description = "Run lint"

--- a/src/configuration/mod.rs
+++ b/src/configuration/mod.rs
@@ -7,6 +7,7 @@ pub use prima::{Environment, PrimaConfiguration};
 pub use test::TestConfiguration;
 
 /// A trait representing a valid configuration entity
+#[allow(clippy::wrong_self_convention)]
 pub trait Configuration {
     /// The address of the udp socket we'll bind to for sending
     fn to_addr(&self) -> &str;

--- a/src/macros/count.rs
+++ b/src/macros/count.rs
@@ -1,48 +1,16 @@
 /// Make an arbitrary change to a StatsD counter
 #[macro_export]
-#[cfg(not(feature = "noop"))]
 macro_rules! count {
     ($stat:expr, $count:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().count($stat, $count, vec![]);
-        }
+        $crate::Datadog::global().count($stat, $count, vec![]);
     };
     ($stat:path, $count:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().count($stat.as_ref(), $count, vec![]);
-        }
+        $crate::Datadog::global().count($stat.as_ref(), $count, vec![]);
     };
     ($stat:expr, $count:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().count($stat, $count, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
+        $crate::Datadog::global().count($stat, $count, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
     ($stat:path, $count:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().count($stat.as_ref(), $count, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
-    };
-}
-
-#[macro_export]
-#[cfg(feature = "noop")]
-macro_rules! count {
-    ($stat:expr, $count:expr) => {
-        let _ = $stat;
-        let _ = $count;
-    };
-    ($stat:path, $count:expr) => {
-        let _ = $stat;
-        let _ = $count;
-    };
-    ($stat:expr, $count:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $count;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:path, $count:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $count;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
+        $crate::Datadog::global().count($stat.as_ref(), $count, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
 }

--- a/src/macros/decr.rs
+++ b/src/macros/decr.rs
@@ -1,44 +1,16 @@
 /// Decrement a StatsD counter
 #[macro_export]
-#[cfg(not(feature = "noop"))]
 macro_rules! decr {
     ($stat:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().decr($stat, vec![]);
-        }
+        $crate::Datadog::global().decr($stat, vec![]);
     };
     ($stat:path) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().decr($stat.as_ref(), vec![]);
-        }
+        $crate::Datadog::global().decr($stat.as_ref(), vec![]);
     };
     ($stat:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().decr($stat, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
+        $crate::Datadog::global().decr($stat, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
     ($stat:path; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().decr($stat.as_ref(), std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
-    };
-}
-
-#[macro_export]
-#[cfg(feature = "noop")]
-macro_rules! decr {
-    ($stat:expr) => {
-        let _ = $stat;
-    };
-    ($stat:path) => {
-        let _ = $stat;
-    };
-    ($stat:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:path; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
+        $crate::Datadog::global().decr($stat.as_ref(), std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
 }

--- a/src/macros/distribution.rs
+++ b/src/macros/distribution.rs
@@ -1,48 +1,16 @@
 /// Report a value in a distribution
 #[macro_export]
-#[cfg(not(feature = "noop"))]
 macro_rules! distribution {
     ($stat:expr, $val:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().distribution($stat, $val, vec![]);
-        }
+        $crate::Datadog::global().distribution($stat, $val, vec![]);
     };
     ($stat:path, $val:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().distribution($stat.as_ref(), $val, vec![]);
-        }
+        $crate::Datadog::global().distribution($stat.as_ref(), $val, vec![]);
     };
     ($stat:expr, $val:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().distribution($stat, $val, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
+        $crate::Datadog::global().distribution($stat, $val, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
     ($stat:path, $val:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().distribution($stat.as_ref(), $val, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
-    };
-}
-
-#[macro_export]
-#[cfg(feature = "noop")]
-macro_rules! distribution {
-    ($stat:expr, $val:expr) => {
-        let _ = $stat;
-        let _ = $val;
-    };
-    ($stat:path, $val:expr) => {
-        let _ = $stat;
-        let _ = $val;
-    };
-    ($stat:expr, $val:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $val;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:path, $val:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $val;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
+        $crate::Datadog::global().distribution($stat.as_ref(), $val, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
 }

--- a/src/macros/event.rs
+++ b/src/macros/event.rs
@@ -1,48 +1,16 @@
 /// Send a custom event as a title and a body
 #[macro_export]
-#[cfg(not(feature = "noop"))]
 macro_rules! event {
     ($stat:path, $text:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().event($stat.as_ref(), $text, vec![]);
-        }
+        $crate::Datadog::global().event($stat.as_ref(), $text, vec![]);
     };
     ($stat:expr, $text:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().event($stat, $text, vec![]);
-        }
+        $crate::Datadog::global().event($stat, $text, vec![]);
     };
     ($stat:expr, $text:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().event($stat, $text, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
+        $crate::Datadog::global().event($stat, $text, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
     ($stat:path, $text:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().event($stat.as_ref(), $text, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
-    };
-}
-
-#[macro_export]
-#[cfg(feature = "noop")]
-macro_rules! event {
-    ($stat:expr, $text:expr) => {
-        let _ = $stat;
-        let _ = $text;
-    };
-    ($stat:path, $text:expr) => {
-        let _ = $stat;
-        let _ = $text;
-    };
-    ($stat:expr, $text:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $text;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:path, $text:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $text;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
+        $crate::Datadog::global().event($stat.as_ref(), $text, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
 }

--- a/src/macros/gauge.rs
+++ b/src/macros/gauge.rs
@@ -1,48 +1,16 @@
 /// Report an arbitrary value as a gauge
 #[macro_export]
-#[cfg(not(feature = "noop"))]
 macro_rules! gauge {
     ($stat:expr, $val:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().gauge($stat, $val, vec![]);
-        }
+        $crate::Datadog::global().gauge($stat, $val, vec![]);
     };
     ($stat:path, $val:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().gauge($stat.as_ref(), $val, vec![]);
-        }
+        $crate::Datadog::global().gauge($stat.as_ref(), $val, vec![]);
     };
     ($stat:expr, $val:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().gauge($stat, $val, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
+        $crate::Datadog::global().gauge($stat, $val, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
     ($stat:path, $val:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().gauge($stat.as_ref(), $val, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
-    };
-}
-
-#[macro_export]
-#[cfg(feature = "noop")]
-macro_rules! gauge {
-    ($stat:expr, $val:expr) => {
-        let _ = $stat;
-        let _ = $val;
-    };
-    ($stat:path, $val:expr) => {
-        let _ = $stat;
-        let _ = $val;
-    };
-    ($stat:expr, $val:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $val;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:path, $val:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $val;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
+        $crate::Datadog::global().gauge($stat.as_ref(), $val, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
 }

--- a/src/macros/histogram.rs
+++ b/src/macros/histogram.rs
@@ -1,48 +1,16 @@
 /// Report a value in a histogram
 #[macro_export]
-#[cfg(not(feature = "noop"))]
 macro_rules! histogram {
     ($stat:expr, $val:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().histogram($stat, $val, vec![]);
-        }
+        $crate::Datadog::global().histogram($stat, $val, vec![]);
     };
     ($stat:path, $val:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().histogram($stat.as_ref(), $val, vec![]);
-        }
+        $crate::Datadog::global().histogram($stat.as_ref(), $val, vec![]);
     };
     ($stat:expr, $val:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().histogram($stat, $val, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
+        $crate::Datadog::global().histogram($stat, $val, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
     ($stat:path, $val:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().histogram($stat.as_ref(), $val, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
-    };
-}
-
-#[macro_export]
-#[cfg(feature = "noop")]
-macro_rules! histogram {
-    ($stat:expr, $val:expr) => {
-        let _ = $stat;
-        let _ = $val;
-    };
-    ($stat:path, $val:expr) => {
-        let _ = $stat;
-        let _ = $val;
-    };
-    ($stat:expr, $val:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $val;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:path, $val:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $val;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
+        $crate::Datadog::global().histogram($stat.as_ref(), $val, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
 }

--- a/src/macros/incr.rs
+++ b/src/macros/incr.rs
@@ -1,44 +1,16 @@
 /// Increment a StatsD counter
 #[macro_export]
-#[cfg(not(feature = "noop"))]
 macro_rules! incr {
     ($stat:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().incr($stat, vec![]);
-        }
+        $crate::Datadog::global().incr($stat, vec![]);
     };
     ($stat:path) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().incr($stat.as_ref(), vec![]);
-        }
+        $crate::Datadog::global().incr($stat.as_ref(), vec![]);
     };
     ($stat:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().incr($stat, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
+        $crate::Datadog::global().incr($stat, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
     ($stat:path; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().incr($stat.as_ref(), std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
-    };
-}
-
-#[macro_export]
-#[cfg(feature = "noop")]
-macro_rules! incr {
-    ($stat:expr) => {
-        let _ = $stat;
-    };
-    ($stat:path) => {
-        let _ = $stat;
-    };
-    ($stat:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:path; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
+        $crate::Datadog::global().incr($stat.as_ref(), std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
 }

--- a/src/macros/service_check.rs
+++ b/src/macros/service_check.rs
@@ -1,116 +1,32 @@
 /// Report the status of a service
 #[macro_export]
-#[cfg(not(feature = "noop"))]
 macro_rules! service_check {
     // call with literal and status
     ($stat:expr, $service_status:path) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().service_check($stat, $service_status, vec![], None);
-        }
+        $crate::Datadog::global().service_check($stat, $service_status, vec![], None);
     };
     ($stat:expr, $service_status:path, $options: expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().service_check($stat, $service_status, vec![], Some($options));
-        }
+        $crate::Datadog::global().service_check($stat, $service_status, vec![], Some($options));
     };
     // call with path, status and options
     ($stat:path, $service_status:path) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().service_check($stat.as_ref(), $service_status, vec![], None);
-        }
+        $crate::Datadog::global().service_check($stat.as_ref(), $service_status, vec![], None);
     };
     ($stat:path, $service_status:path, $options: expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().service_check($stat.as_ref(), $service_status, vec![], Some($options));
-        }
+        $crate::Datadog::global().service_check($stat.as_ref(), $service_status, vec![], Some($options));
     };
     // call with literal, status, options and tags
     ($stat:expr, $service_status:path; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().service_check($stat, $service_status, std::vec![$(std::format!("{}:{}", $key, $value)), *], None);
-        }
+        $crate::Datadog::global().service_check($stat, $service_status, std::vec![$(std::format!("{}:{}", $key, $value)), *], None);
     };
     ($stat:expr, $service_status:path, $options: expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().service_check($stat, $service_status, std::vec![$(std::format!("{}:{}", $key, $value)), *], Some($options));
-        }
+        $crate::Datadog::global().service_check($stat, $service_status, std::vec![$(std::format!("{}:{}", $key, $value)), *], Some($options));
     };
     // call with path, status, options and tags
     ($stat:path, $service_status:path; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().service_check($stat.as_ref(), $service_status, std::vec![$(std::format!("{}:{}", $key, $value)), *], None);
-        }
+        $crate::Datadog::global().service_check($stat.as_ref(), $service_status, std::vec![$(std::format!("{}:{}", $key, $value)), *], None);
     };
     ($stat:path, $service_status:path, $options: expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().service_check($stat.as_ref(), $service_status, std::vec![$(std::format!("{}:{}", $key, $value)), *], Some($options));
-        }
-    };
-}
-
-#[macro_export]
-#[cfg(feature = "noop")]
-macro_rules! service_check {
-    ($stat:expr, $service_status:path) => {
-        let _ = $stat;
-        let _ = $service_status;
-    };
-    ($stat:expr, $service_status:path, $options: ident) => {
-        let _ = $stat;
-        let _ = $service_status;
-        let _ = $options;
-    };
-    ($stat:expr, $service_status:path, $options: expr) => {
-        let _ = $stat;
-        let _ = $service_status;
-        let _ = $options;
-    };
-    ($stat:path, $service_status:path) => {
-        let _ = $stat;
-        let _ = $service_status;
-    };
-    ($stat:path, $service_status:path, $options: ident) => {
-        let _ = $stat;
-        let _ = $service_status;
-        let _ = $options;
-    };
-    ($stat:path, $service_status:path, $options: expr) => {
-        let _ = $stat;
-        let _ = $service_status;
-        let _ = $options;
-    };
-    ($stat:expr, $service_status:path; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $service_status;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:expr, $service_status:path, $options: ident; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $service_status;
-        let _ = $options;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:expr, $service_status:path, $options: expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $service_status;
-        let _ = $options;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:path, $service_status:path; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $service_status;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:path, $service_status:path, $options: ident; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $service_status;
-        let _ = $options;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:path, $service_status:path, $options: expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $service_status;
-        let _ = $options;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
+        $crate::Datadog::global().service_check($stat.as_ref(), $service_status, std::vec![$(std::format!("{}:{}", $key, $value)), *], Some($options));
     };
 }

--- a/src/macros/set.rs
+++ b/src/macros/set.rs
@@ -1,48 +1,16 @@
 /// Report a value in a set
 #[macro_export]
-#[cfg(not(feature = "noop"))]
 macro_rules! set {
     ($stat:expr, $val:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().set($stat, $val, vec![]);
-        }
+        $crate::Datadog::global().set($stat, $val, vec![]);
     };
     ($stat:path, $val:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().set($stat.as_ref(), $val, vec![]);
-        }
+        $crate::Datadog::global().set($stat.as_ref(), $val, vec![]);
     };
     ($stat:expr, $val:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().set($stat, $val, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
+        $crate::Datadog::global().set($stat, $val, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
     ($stat:path, $val:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().set($stat.as_ref(), $val, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
-    };
-}
-
-#[macro_export]
-#[cfg(feature = "noop")]
-macro_rules! set {
-    ($stat:expr, $val:expr) => {
-        let _ = $stat;
-        let _ = $val;
-    };
-    ($stat:path, $val:expr) => {
-        let _ = $stat;
-        let _ = $val;
-    };
-    ($stat:expr, $val:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $val;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:path, $val:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $val;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
+        $crate::Datadog::global().set($stat.as_ref(), $val, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
 }

--- a/src/macros/time.rs
+++ b/src/macros/time.rs
@@ -1,85 +1,28 @@
 /// Time a block of code (reports in ms)
 #[macro_export]
-#[cfg(not(feature = "noop"))]
 macro_rules! time {
     ($stat:expr, || $block:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().time($stat, vec![], || $block);
-        }
+        $crate::Datadog::global().time($stat, vec![], || $block);
     };
     ($stat:expr, move || $block:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().time($stat, vec![], || $block);
-        }
+        $crate::Datadog::global().time($stat, vec![], || $block);
     };
     ($stat:path, || $block:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().time($stat.as_ref(), vec![], || $block);
-        }
+        $crate::Datadog::global().time($stat.as_ref(), vec![], || $block);
     };
     ($stat:path, move || $block:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().time($stat.as_ref(), vec![], || $block);
-        }
+        $crate::Datadog::global().time($stat.as_ref(), vec![], || $block);
     };
     ($stat:expr, || $block:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().time($stat, std::vec![$(std::format!("{}:{}", $key, $value)), *], || $block);
-        }
+        $crate::Datadog::global().time($stat, std::vec![$(std::format!("{}:{}", $key, $value)), *], || $block);
     };
     ($stat:expr, move || $block:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().time($stat, std::vec![$(std::format!("{}:{}", $key, $value)), *], || $block);
-        }
+        $crate::Datadog::global().time($stat, std::vec![$(std::format!("{}:{}", $key, $value)), *], || $block);
     };
     ($stat:path, || $block:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().time($stat.as_ref(), $count, std::vec![$(std::format!("{}:{}", $key, $value)), *], || $block);
-        }
+        $crate::Datadog::global().time($stat.as_ref(), $count, std::vec![$(std::format!("{}:{}", $key, $value)), *], || $block);
     };
     ($stat:path, move || $block:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().time($stat.as_ref(), $count, std::vec![$(std::format!("{}:{}", $key, $value)), *], || $block);
-        }
+        $crate::Datadog::global().time($stat.as_ref(), $count, std::vec![$(std::format!("{}:{}", $key, $value)), *], || $block);
     };
-}
-
-#[macro_export]
-#[cfg(feature = "noop")]
-macro_rules! time {
-    ($stat:expr, || $block:expr) => {
-        let _ = $stat;
-        let _ = $block;
-    };
-    ($stat:expr, move || $block:expr) => {
-        let _ = $stat;
-        let _ = $block;
-    };
-    ($stat:path, || $block:expr) => {
-        let _ = $stat;
-        let _ = $block;
-    };
-    ($stat:path, move || $block:expr) => {
-        let _ = $stat;
-        let _ = $block;
-    };
-    ($stat:expr, || $block:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $block;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:expr, move || $block:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $block;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:path, || $block:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $block;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:path, move || $block:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $block;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];};
 }

--- a/src/macros/timing.rs
+++ b/src/macros/timing.rs
@@ -1,48 +1,16 @@
 /// Send your own timing metric in milliseconds
 #[macro_export]
-#[cfg(not(feature = "noop"))]
 macro_rules! timing {
     ($stat:expr, $ms:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().timing($stat, $ms, vec![]);
-        }
+        $crate::Datadog::global().timing($stat, $ms, vec![]);
     };
     ($stat:path, $ms:expr) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().timing($stat.as_ref(), $ms, vec![]);
-        }
+        $crate::Datadog::global().timing($stat.as_ref(), $ms, vec![]);
     };
     ($stat:expr, $ms:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().timing($stat, $ms, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
+        $crate::Datadog::global().timing($stat, $ms, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
     ($stat:path, $ms:expr; $( $key:expr => $value:expr ), *) => {
-        if $crate::Datadog::global().is_reporting_enabled() {
-            $crate::Datadog::global().timing($stat.as_ref(), $ms, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
-        }
-    };
-}
-
-#[macro_export]
-#[cfg(feature = "noop")]
-macro_rules! timing {
-    ($stat:expr, $ms:expr) => {
-        let _ = $stat;
-        let _ = $ms;
-    };
-    ($stat:path, $ms:expr) => {
-        let _ = $stat;
-        let _ = $ms;
-    };
-    ($stat:expr, $ms:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $ms;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
-    };
-    ($stat:path, $ms:expr; $( $key:expr => $value:expr ), *) => {
-        let _ = $stat;
-        let _ = $ms;
-        let _ = std::vec![$(std::format!("{}:{}", $key, $value)), *];
+        $crate::Datadog::global().timing($stat.as_ref(), $ms, std::vec![$(std::format!("{}:{}", $key, $value)), *]);
     };
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -15,24 +15,3 @@ impl std::fmt::Display for TestEvent {
         write!(f, "{}", self.as_ref())
     }
 }
-
-#[cfg(feature = "noop")]
-pub enum TestEvent2 {
-    Test2,
-}
-
-#[cfg(feature = "noop")]
-impl AsRef<str> for TestEvent2 {
-    fn as_ref(&self) -> &str {
-        match self {
-            TestEvent2::Test2 => "test2_event",
-        }
-    }
-}
-
-#[cfg(feature = "noop")]
-impl std::fmt::Display for TestEvent2 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.as_ref())
-    }
-}

--- a/tests/count.rs
+++ b/tests/count.rs
@@ -6,49 +6,23 @@ use prima_datadog::Datadog;
 #[test]
 pub fn count_with_literal() {
     let mock = mocks::count_mock("test", 10, &[]);
-    Datadog::new(mock, true).count("test", 10, vec![]);
+    Datadog::new(mock).count("test", 10, vec![]);
 }
 
 #[test]
 pub fn count_with_type() {
     let mock = mocks::count_mock("test1_event", 10, &[]);
-    Datadog::new(mock, true).count(common::TestEvent::Test1, 10, vec![]);
+    Datadog::new(mock).count(common::TestEvent::Test1, 10, vec![]);
 }
 
 #[test]
 pub fn count_with_literal_and_tags() {
     let mock = mocks::count_mock("test", 10, &["added:tag", "env:test"]);
-    Datadog::new(mock, true).count("test", 10, vec!["added:tag".to_string()]);
+    Datadog::new(mock).count("test", 10, vec!["added:tag".to_string()]);
 }
 
 #[test]
 pub fn count_with_type_and_tags() {
     let mock = mocks::count_mock("test1_event", 10, &["added:tag", "env:test"]);
-    Datadog::new(mock, true).count(common::TestEvent::Test1, 10, vec!["added:tag".to_string()]);
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_count_with_literal() {
-    prima_datadog::count!("test", 10);
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_count_with_type() {
-    use common::TestEvent;
-    prima_datadog::count!(TestEvent::Test1, 10);
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_count_with_literal_and_tags() {
-    prima_datadog::count!("test", 10; "added" => "tag");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_count_with_type_and_tags() {
-    use common::{TestEvent, TestEvent2};
-    prima_datadog::count!(TestEvent::Test1, 10; "added" => TestEvent2::Test2);
+    Datadog::new(mock).count(common::TestEvent::Test1, 10, vec!["added:tag".to_string()]);
 }

--- a/tests/decr.rs
+++ b/tests/decr.rs
@@ -6,49 +6,23 @@ use prima_datadog::Datadog;
 #[test]
 pub fn decr_with_literal() {
     let mock = mocks::decr_mock("test", &[]);
-    Datadog::new(mock, true).decr("test", vec![]);
+    Datadog::new(mock).decr("test", vec![]);
 }
 
 #[test]
 pub fn decr_with_type() {
     let mock = mocks::decr_mock("test1_event", &[]);
-    Datadog::new(mock, true).decr(common::TestEvent::Test1, vec![]);
+    Datadog::new(mock).decr(common::TestEvent::Test1, vec![]);
 }
 
 #[test]
 pub fn decr_with_literal_and_tags() {
     let mock = mocks::decr_mock("test", &["added:tag", "env:test"]);
-    Datadog::new(mock, true).decr("test", vec!["added:tag".to_string()]);
+    Datadog::new(mock).decr("test", vec!["added:tag".to_string()]);
 }
 
 #[test]
 pub fn decr_with_type_and_tags() {
     let mock = mocks::decr_mock("test1_event", &["added:tag", "env:test"]);
-    Datadog::new(mock, true).decr(common::TestEvent::Test1, vec!["added:tag".to_string()]);
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_decr_with_literal() {
-    prima_datadog::decr!("test");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_decr_with_type() {
-    use common::TestEvent;
-    prima_datadog::decr!(TestEvent::Test1);
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_decr_with_literal_and_tags() {
-    prima_datadog::decr!("test"; "added" => "tag");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_decr_with_type_and_tags() {
-    use common::{TestEvent, TestEvent2};
-    prima_datadog::decr!(TestEvent::Test1; TestEvent2::Test2 => "tag");
+    Datadog::new(mock).decr(common::TestEvent::Test1, vec!["added:tag".to_string()]);
 }

--- a/tests/distribution.rs
+++ b/tests/distribution.rs
@@ -6,49 +6,23 @@ use prima_datadog::Datadog;
 #[test]
 pub fn distribution_with_literal() {
     let mock = mocks::distribution_mock("test", "test_value", &[]);
-    Datadog::new(mock, true).distribution("test", "test_value", vec![]);
+    Datadog::new(mock).distribution("test", "test_value", vec![]);
 }
 
 #[test]
 pub fn distribution_with_type() {
     let mock = mocks::distribution_mock("test1_event", "test_value", &[]);
-    Datadog::new(mock, true).distribution(common::TestEvent::Test1, "test_value", vec![]);
+    Datadog::new(mock).distribution(common::TestEvent::Test1, "test_value", vec![]);
 }
 
 #[test]
 pub fn distribution_with_literal_and_tags() {
     let mock = mocks::distribution_mock("test", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true).distribution("test", "test_value", vec!["added:tag".to_string()]);
+    Datadog::new(mock).distribution("test", "test_value", vec!["added:tag".to_string()]);
 }
 
 #[test]
 pub fn distribution_with_type_and_tags() {
     let mock = mocks::distribution_mock("test1_event", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true).distribution(common::TestEvent::Test1, "test_value", vec!["added:tag".to_string()]);
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_distribution_with_literal() {
-    prima_datadog::distribution!("test", "test_value");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_distribution_with_type() {
-    use common::TestEvent;
-    prima_datadog::distribution!(TestEvent::Test1, "test_value");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_distribution_with_literal_and_tags() {
-    prima_datadog::distribution!("test", "test_value"; "added" => "tag");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_distribution_with_type_and_tags() {
-    use common::{TestEvent, TestEvent2};
-    prima_datadog::distribution!(TestEvent::Test1, "test_value"; "added" => TestEvent2::Test2);
+    Datadog::new(mock).distribution(common::TestEvent::Test1, "test_value", vec!["added:tag".to_string()]);
 }

--- a/tests/end_to_end_runner.rs
+++ b/tests/end_to_end_runner.rs
@@ -1,2 +1,1 @@
-#[cfg(not(feature = "noop"))]
 mod end_to_end;

--- a/tests/event.rs
+++ b/tests/event.rs
@@ -6,49 +6,23 @@ use prima_datadog::Datadog;
 #[test]
 pub fn event_with_literal() {
     let mock = mocks::event_mock("test", "test_value", &[]);
-    Datadog::new(mock, true).event("test", "test_value", vec![]);
+    Datadog::new(mock).event("test", "test_value", vec![]);
 }
 
 #[test]
 pub fn event_with_type() {
     let mock = mocks::event_mock("test1_event", "test_value", &[]);
-    Datadog::new(mock, true).event(common::TestEvent::Test1, "test_value", vec![]);
+    Datadog::new(mock).event(common::TestEvent::Test1, "test_value", vec![]);
 }
 
 #[test]
 pub fn event_with_literal_and_tags() {
     let mock = mocks::event_mock("test", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true).event("test", "test_value", vec!["added:tag".to_string()]);
+    Datadog::new(mock).event("test", "test_value", vec!["added:tag".to_string()]);
 }
 
 #[test]
 pub fn event_with_type_and_tags() {
     let mock = mocks::event_mock("test1_event", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true).event(common::TestEvent::Test1, "test_value", vec!["added:tag".to_string()]);
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_event_with_literal() {
-    prima_datadog::event!("test", "test_value");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_event_with_type() {
-    use common::TestEvent;
-    prima_datadog::event!(TestEvent::Test1, "test_value");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_event_with_literal_and_tags() {
-    prima_datadog::event!("test", "test_value"; "added" => "tag");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_event_with_type_and_tags() {
-    use common::{TestEvent, TestEvent2};
-    prima_datadog::event!(TestEvent::Test1, "test_value"; "added" => TestEvent2::Test2);
+    Datadog::new(mock).event(common::TestEvent::Test1, "test_value", vec!["added:tag".to_string()]);
 }

--- a/tests/gauge.rs
+++ b/tests/gauge.rs
@@ -6,49 +6,23 @@ use prima_datadog::Datadog;
 #[test]
 pub fn gauge_with_literal() {
     let mock = mocks::gauge_mock("test", "test_value", &[]);
-    Datadog::new(mock, true).gauge("test", "test_value", vec![]);
+    Datadog::new(mock).gauge("test", "test_value", vec![]);
 }
 
 #[test]
 pub fn gauge_with_type() {
     let mock = mocks::gauge_mock("test1_event", "test_value", &[]);
-    Datadog::new(mock, true).gauge(common::TestEvent::Test1, "test_value", vec![]);
+    Datadog::new(mock).gauge(common::TestEvent::Test1, "test_value", vec![]);
 }
 
 #[test]
 pub fn gauge_with_literal_and_tags() {
     let mock = mocks::gauge_mock("test", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true).gauge("test", "test_value", vec!["added:tag".to_string()]);
+    Datadog::new(mock).gauge("test", "test_value", vec!["added:tag".to_string()]);
 }
 
 #[test]
 pub fn gauge_with_type_and_tags() {
     let mock = mocks::gauge_mock("test1_event", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true).gauge(common::TestEvent::Test1, "test_value", vec!["added:tag".to_string()]);
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_gauge_with_literal() {
-    prima_datadog::gauge!("test", "test_value");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_gauge_with_type() {
-    use common::TestEvent;
-    prima_datadog::gauge!(TestEvent::Test1, "test_value");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_gauge_with_literal_and_tags() {
-    prima_datadog::gauge!("test", "test_value"; "added" => "tag");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_gauge_with_type_and_tags() {
-    use common::{TestEvent, TestEvent2};
-    prima_datadog::gauge!(TestEvent::Test1, "test_value"; TestEvent2::Test2 => "tag");
+    Datadog::new(mock).gauge(common::TestEvent::Test1, "test_value", vec!["added:tag".to_string()]);
 }

--- a/tests/histogram.rs
+++ b/tests/histogram.rs
@@ -6,49 +6,23 @@ use prima_datadog::Datadog;
 #[test]
 pub fn histogram_with_literal() {
     let mock = mocks::histogram_mock("test", "test_value", &[]);
-    Datadog::new(mock, true).histogram("test", "test_value", vec![]);
+    Datadog::new(mock).histogram("test", "test_value", vec![]);
 }
 
 #[test]
 pub fn histogram_with_type() {
     let mock = mocks::histogram_mock("test1_event", "test_value", &[]);
-    Datadog::new(mock, true).histogram(common::TestEvent::Test1, "test_value", vec![]);
+    Datadog::new(mock).histogram(common::TestEvent::Test1, "test_value", vec![]);
 }
 
 #[test]
 pub fn histogram_with_literal_and_tags() {
     let mock = mocks::histogram_mock("test", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true).histogram("test", "test_value", vec!["added:tag".to_string()]);
+    Datadog::new(mock).histogram("test", "test_value", vec!["added:tag".to_string()]);
 }
 
 #[test]
 pub fn histogram_with_type_and_tags() {
     let mock = mocks::histogram_mock("test1_event", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true).histogram(common::TestEvent::Test1, "test_value", vec!["added:tag".to_string()]);
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_histogram_with_literal() {
-    prima_datadog::histogram!("test", "test_value");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_histogram_with_type() {
-    use common::TestEvent;
-    prima_datadog::histogram!(TestEvent::Test1, "test_value");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_histogram_with_literal_and_tags() {
-    prima_datadog::histogram!("test", "test_value"; "added" => "tag");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_histogram_with_type_and_tags() {
-    use common::{TestEvent, TestEvent2};
-    prima_datadog::histogram!(TestEvent::Test1, "test_value"; "added" => TestEvent2::Test2);
+    Datadog::new(mock).histogram(common::TestEvent::Test1, "test_value", vec!["added:tag".to_string()]);
 }

--- a/tests/incr.rs
+++ b/tests/incr.rs
@@ -6,49 +6,23 @@ use prima_datadog::Datadog;
 #[test]
 pub fn incr_with_literal() {
     let mock = mocks::incr_mock("test", &[]);
-    Datadog::new(mock, true).incr("test", vec![]);
+    Datadog::new(mock).incr("test", vec![]);
 }
 
 #[test]
 pub fn incr_with_type() {
     let mock = mocks::incr_mock("test1_event", &[]);
-    Datadog::new(mock, true).incr(common::TestEvent::Test1, vec![]);
+    Datadog::new(mock).incr(common::TestEvent::Test1, vec![]);
 }
 
 #[test]
 pub fn incr_with_literal_and_tags() {
     let mock = mocks::incr_mock("test", &["added:tag", "env:test"]);
-    Datadog::new(mock, true).incr("test", vec!["added:tag".to_string()]);
+    Datadog::new(mock).incr("test", vec!["added:tag".to_string()]);
 }
 
 #[test]
 pub fn incr_with_type_and_tags() {
     let mock = mocks::incr_mock("test1_event", &["added:tag", "env:test"]);
-    Datadog::new(mock, true).incr(common::TestEvent::Test1, vec!["added:tag".to_string()]);
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_incr_with_literal() {
-    prima_datadog::incr!("test");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_incr_with_type() {
-    use common::TestEvent;
-    prima_datadog::incr!(TestEvent::Test1);
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_incr_with_literal_and_tags() {
-    prima_datadog::incr!("test"; "added" => "tag");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_incr_with_type_and_tags() {
-    use common::{TestEvent, TestEvent2};
-    prima_datadog::incr!(TestEvent::Test1; TestEvent2::Test2 => "tag");
+    Datadog::new(mock).incr(common::TestEvent::Test1, vec!["added:tag".to_string()]);
 }

--- a/tests/service_check.rs
+++ b/tests/service_check.rs
@@ -6,7 +6,7 @@ use prima_datadog::{Datadog, ServiceCheckOptions, ServiceStatus};
 #[test]
 pub fn service_check_with_literal() {
     let mock = mocks::service_check_mock("test", ServiceStatus::OK, &[], Some(ServiceCheckOptions::default()));
-    Datadog::new(mock, true).service_check("test", ServiceStatus::OK, vec![], Some(ServiceCheckOptions::default()));
+    Datadog::new(mock).service_check("test", ServiceStatus::OK, vec![], Some(ServiceCheckOptions::default()));
 }
 
 #[test]
@@ -17,7 +17,7 @@ pub fn service_check_with_type() {
         &[],
         Some(ServiceCheckOptions::default()),
     );
-    Datadog::new(mock, true).service_check(
+    Datadog::new(mock).service_check(
         common::TestEvent::Test1,
         ServiceStatus::OK,
         vec![],
@@ -33,7 +33,7 @@ pub fn service_check_with_literal_and_tags() {
         &["added:tag", "env:test"],
         Some(ServiceCheckOptions::default()),
     );
-    Datadog::new(mock, true).service_check(
+    Datadog::new(mock).service_check(
         "test",
         ServiceStatus::OK,
         vec!["added:tag".to_string()],
@@ -44,50 +44,10 @@ pub fn service_check_with_literal_and_tags() {
 #[test]
 pub fn service_check_with_type_and_tags() {
     let mock = mocks::service_check_mock("test1_event", ServiceStatus::OK, &["added:tag", "env:test"], None);
-    Datadog::new(mock, true).service_check(
+    Datadog::new(mock).service_check(
         common::TestEvent::Test1,
         ServiceStatus::OK,
         vec!["added:tag".to_string()],
         None,
-    );
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_service_check_with_literal() {
-    prima_datadog::service_check!("test", ServiceStatus::OK, Some(ServiceCheckOptions::default()));
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_service_check_with_type() {
-    use common::TestEvent;
-    prima_datadog::service_check!(
-        TestEvent::Test1,
-        ServiceStatus::OK,
-        Some(ServiceCheckOptions::default())
-    );
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_service_check_with_literal_and_tags() {
-    prima_datadog::service_check!(
-        "test",
-        ServiceStatus::OK,
-        Some(ServiceCheckOptions::default());
-        "added" => "tag"
-    );
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_service_check_with_type_and_tags() {
-    use common::{TestEvent, TestEvent2};
-    prima_datadog::service_check!(
-        TestEvent::Test1,
-        ServiceStatus::OK,
-        None as Option<ServiceCheckOptions>; // TODO: maybe there's a better way to solve type annotations needed for `Option<T>`?
-        TestEvent2::Test2 => "tag"
     );
 }

--- a/tests/set.rs
+++ b/tests/set.rs
@@ -6,49 +6,23 @@ use prima_datadog::Datadog;
 #[test]
 pub fn set_with_literal() {
     let mock = mocks::set_mock("test", "test_value", &[]);
-    Datadog::new(mock, true).set("test", "test_value", vec![]);
+    Datadog::new(mock).set("test", "test_value", vec![]);
 }
 
 #[test]
 pub fn set_with_type() {
     let mock = mocks::set_mock("test1_event", "test_value", &[]);
-    Datadog::new(mock, true).set(common::TestEvent::Test1, "test_value", vec![]);
+    Datadog::new(mock).set(common::TestEvent::Test1, "test_value", vec![]);
 }
 
 #[test]
 pub fn set_with_literal_and_tags() {
     let mock = mocks::set_mock("test", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true).set("test", "test_value", vec!["added:tag".to_string()]);
+    Datadog::new(mock).set("test", "test_value", vec!["added:tag".to_string()]);
 }
 
 #[test]
 pub fn set_with_type_and_tags() {
     let mock = mocks::set_mock("test1_event", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true).set(common::TestEvent::Test1, "test_value", vec!["added:tag".to_string()]);
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_set_with_literal() {
-    prima_datadog::set!("test", "test_value");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_set_with_type() {
-    use common::TestEvent;
-    prima_datadog::set!(TestEvent::Test1, "test_value");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_set_with_literal_and_tags() {
-    prima_datadog::set!("test", "test_value"; "added" => "tag");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_set_with_type_and_tags() {
-    use common::{TestEvent, TestEvent2};
-    prima_datadog::set!(TestEvent::Test1, "test_value"; "added" => TestEvent2::Test2);
+    Datadog::new(mock).set(common::TestEvent::Test1, "test_value", vec!["added:tag".to_string()]);
 }

--- a/tests/time.rs
+++ b/tests/time.rs
@@ -6,49 +6,23 @@ use prima_datadog::Datadog;
 #[test]
 pub fn time_with_literal() {
     let mock = mocks::time_mock("test", &[]);
-    Datadog::new(mock, true).time("test", vec![], || {});
+    Datadog::new(mock).time("test", vec![], || {});
 }
 
 #[test]
 pub fn time_with_type() {
     let mock = mocks::time_mock("test1_event", &[]);
-    Datadog::new(mock, true).time(common::TestEvent::Test1, vec![], || {});
+    Datadog::new(mock).time(common::TestEvent::Test1, vec![], || {});
 }
 
 #[test]
 pub fn time_with_literal_and_tags() {
     let mock = mocks::time_mock("test", &["added:tag", "env:test"]);
-    Datadog::new(mock, true).time("test", vec!["added:tag".to_string()], || {});
+    Datadog::new(mock).time("test", vec!["added:tag".to_string()], || {});
 }
 
 #[test]
 pub fn time_with_type_and_tags() {
     let mock = mocks::time_mock("test1_event", &["added:tag", "env:test"]);
-    Datadog::new(mock, true).time(common::TestEvent::Test1, vec!["added:tag".to_string()], || {});
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_time_with_literal() {
-    prima_datadog::time!("test", || {});
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_time_with_type() {
-    use common::TestEvent;
-    prima_datadog::time!(TestEvent::Test1, || {});
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_time_with_literal_and_tags() {
-    prima_datadog::time!("test", || {}; "added" => "tag");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_time_with_type_and_tags() {
-    use common::{TestEvent, TestEvent2};
-    prima_datadog::time!(TestEvent::Test1, || {}; TestEvent2::Test2 => "tag");
+    Datadog::new(mock).time(common::TestEvent::Test1, vec!["added:tag".to_string()], || {});
 }

--- a/tests/timing.rs
+++ b/tests/timing.rs
@@ -6,49 +6,23 @@ use prima_datadog::Datadog;
 #[test]
 pub fn timing_with_literal() {
     let mock = mocks::timing_mock("test", 10, &[]);
-    Datadog::new(mock, true).timing("test", 10, vec![]);
+    Datadog::new(mock).timing("test", 10, vec![]);
 }
 
 #[test]
 pub fn timing_with_type() {
     let mock = mocks::timing_mock("test1_event", 10, &[]);
-    Datadog::new(mock, true).timing(common::TestEvent::Test1, 10, vec![]);
+    Datadog::new(mock).timing(common::TestEvent::Test1, 10, vec![]);
 }
 
 #[test]
 pub fn timing_with_literal_and_tags() {
     let mock = mocks::timing_mock("test", 10, &["added:tag", "env:test"]);
-    Datadog::new(mock, true).timing("test", 10, vec!["added:tag".to_string()]);
+    Datadog::new(mock).timing("test", 10, vec!["added:tag".to_string()]);
 }
 
 #[test]
 pub fn timing_with_type_and_tags() {
     let mock = mocks::timing_mock("test1_event", 10, &["added:tag", "env:test"]);
-    Datadog::new(mock, true).timing(common::TestEvent::Test1, 10, vec!["added:tag".to_string()]);
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_timing_with_literal() {
-    prima_datadog::timing!("test", 10);
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_timing_with_type() {
-    use common::TestEvent;
-    prima_datadog::timing!(TestEvent::Test1, 10);
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_timing_with_literal_and_tags() {
-    prima_datadog::timing!("test", 10; "added" => "tag");
-}
-
-#[test]
-#[cfg(feature = "noop")]
-pub fn macro_timing_with_type_and_tags() {
-    use common::{TestEvent, TestEvent2};
-    prima_datadog::timing!(TestEvent::Test1, 10; "added" => TestEvent2::Test2);
+    Datadog::new(mock).timing(common::TestEvent::Test1, 10, vec!["added:tag".to_string()]);
 }


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-425

Removed the `noop` feature. Everything could be handled by code setting `reporting_enabled` configuration value to `false`.

