### PR TITLE
Restrict dependencies features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dogstatsd = { version = "0.7.1", default-features = false }
-once_cell = "1.9"
-thiserror = "1.0"
+dogstatsd = { version = "0.7", default-features = false }
+once_cell = { version = "1.9", default-features = false, features = ["std"] }
+thiserror = { version = "1.0", default-features = false }
 
 [dev-dependencies]
-mockall = "0.11"
-serial_test = "0.7"
+mockall = { version = "0.11", default-features = false }
+serial_test = { version = "0.8.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dogstatsd = { git =  "https://github.com/mcasper/dogstatsd-rs.git", branch = "master", default-features = false }
+dogstatsd = { version = "0.7.1", default-features = false }
 once_cell = "1.9"
 thiserror = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dogstatsd = { git =  "https://github.com/Guara92/dogstatsd-rs", branch = "reduce_chrono_features", default-features = false}
+dogstatsd = { git =  "https://github.com/Guara92/dogstatsd-rs", branch = "master", default-features = false }
 once_cell = "1.9"
 thiserror = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dogstatsd = { git =  "https://github.com/Guara92/dogstatsd-rs", branch = "master", default-features = false }
+dogstatsd = { git =  "https://github.com/mcasper/dogstatsd-rs.git", branch = "master", default-features = false }
 once_cell = "1.9"
 thiserror = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dogstatsd = "0.7"
+dogstatsd = { git =  "https://github.com/Guara92/dogstatsd-rs", branch = "reduce_chrono_features", default-features = false}
 once_cell = "1.9"
 thiserror = "1.0"
 


### PR DESCRIPTION
Disable default features on each dependency, the only one that should be affected is `serial_test` `logging` features, if it is useful I'll explicitly enable it.