### PR TITLE
[PLATFORM-686]: [PrimaDatadog.rs] Add global to list of countries

### DIFF
--- a/src/configuration/prima.rs
+++ b/src/configuration/prima.rs
@@ -60,7 +60,7 @@ impl Configuration for PrimaConfiguration {
 
 /// Represent an environment in which the datadog client runs.
 /// This is useful for enforcing rules based on environment for every application that uses the library.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum Environment {
     Dev,
     Qa,
@@ -95,7 +95,7 @@ impl Display for Environment {
 
 /// Represents the country in which the datadog client runs.
 /// This is useful for enforcing rules based on country for every application that uses the library.
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Country {
     Common,
     It,

--- a/src/configuration/prima.rs
+++ b/src/configuration/prima.rs
@@ -97,6 +97,7 @@ impl Display for Environment {
 /// This is useful for enforcing rules based on country for every application that uses the library.
 #[derive(PartialEq, Debug, Clone)]
 pub enum Country {
+    Common,
     It,
     Es,
     Uk,
@@ -107,6 +108,7 @@ impl FromStr for Country {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
+            "common" => Ok(Self::Common),
             "it" => Ok(Self::It),
             "es" => Ok(Self::Es),
             "uk" => Ok(Self::Uk),
@@ -118,6 +120,7 @@ impl FromStr for Country {
 impl Display for Country {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Country::Common => write!(f, "common"),
             Country::It => write!(f, "it"),
             Country::Es => write!(f, "es"),
             Country::Uk => write!(f, "uk"),

--- a/src/configuration/prima.rs
+++ b/src/configuration/prima.rs
@@ -96,6 +96,7 @@ impl Display for Environment {
 /// Represents the country in which the datadog client runs.
 /// This is useful for enforcing rules based on country for every application that uses the library.
 #[derive(PartialEq, Eq, Debug, Clone)]
+#[non_exhaustive]
 pub enum Country {
     Common,
     It,


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-686

This PR adds `Country::Common` for services used across all country platforms.

Some extra changes:

- Derived `Eq` as per clippy suggestion
- Added `#[non_exhaustive]` to `Country` as we may launch more country platforms in future
