### PR TITLE
[PLATFORM-804]: Implement serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,19 @@ license = "MIT"
 dogstatsd = { version = "0.7", default-features = false }
 once_cell = { version = "1.9", default-features = false, features = ["std"] }
 thiserror = { version = "1.0", default-features = false }
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 mockall = { version = "0.11", default-features = false }
 serial_test = { version = "0.8.0", default-features = false }
 criterion = "0.3"
+serde_json = "1"
 
 [[bench]]
 name = "basic_incr"
 harness = false
+
+[package.metadata.docs.rs]
+# Allows us to document items as only available with certain feature flags enabled
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 dogstatsd = { version = "0.7", default-features = false }
 once_cell = { version = "1.9", default-features = false, features = ["std"] }
 thiserror = { version = "1.0", default-features = false }
-serde = { version = "1", features = ["derive"], optional = true }
+serde = { version = "1", optional = true }
 
 [dev-dependencies]
 mockall = { version = "0.11", default-features = false }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -14,7 +14,7 @@ args = [
 
 [tasks.test]
 command = "cargo"
-args = ["test"]
+args = ["test", "--all", "--all-features"]
 
 [tasks.lint]
 description = "Run lint"

--- a/src/configuration/prima.rs
+++ b/src/configuration/prima.rs
@@ -72,7 +72,7 @@ impl Configuration for PrimaConfiguration {
 
 /// Represent an environment in which the datadog client runs.
 /// This is useful for enforcing rules based on environment for every application that uses the library.
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Environment {
     Dev,
     Qa,
@@ -151,7 +151,7 @@ impl<'de> serde::Deserialize<'de> for Environment {
 
 /// Represents the country in which the datadog client runs.
 /// This is useful for enforcing rules based on country for every application that uses the library.
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Country {
     Common,
     It,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@
 //!
 //!   - [Datadog docs](https://docs.datadoghq.com/getting_started/)
 //!   - [Getting started with Datadog tags](https://docs.datadoghq.com/getting_started/tagging/)
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![doc(issue_tracker_base_url = "https://github.com/primait/prima_datadog.rs/issues")]
 
 pub use dogstatsd::{ServiceCheckOptions, ServiceStatus};


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-804

This PR implements serde support for a couple of the publicly exported types, namely Country and Environment.

Those were the only publicly exported types I could see maybe needing to be serialized/deserialized.

I've also marked their serde implementations so that they show up on docs.rs as "this requires the feature flag `serde`" for documentation purposes.

And finally I have thrown in a couple bonus tests to this PR and updated the makefile to run those tests with the serde feature flag.
