### PR TITLE
Prepare for 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- A `TimingGuard` guard struct, for more flexible execution time tracking
+- The `compare!` macro, for running experiments in production
+
+### Changed
+- Fixed 0.4.0 backwards compatibility, relating to errors in some macro definitions
+- Fixed various documentation errors
+
 ---
 
 ## [0.4.0] - 2022-11-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.5.0] - 2022-12-05
+
 ### Added
 - A `TimingGuard` guard struct, for more flexible execution time tracking
 - The `compare!` macro, for running experiments in production
@@ -79,7 +83,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.5]
 
 
-[Unreleased]: https://github.com/primait/prima_datadog.rs/compare/0.4.0...HEAD
+
+[Unreleased]: https://github.com/primait/prima_datadog.rs/compare/0.5.0...HEAD
+[0.5.0]: https://github.com/primait/prima_datadog.rs/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/primait/prima_datadog.rs/compare/0.3.1...0.4.0
 [0.3.1]: https://github.com/primait/prima_datadog.rs/compare/0.3.0...0.3.1
 [0.3.0]: https://github.com/primait/prima_datadog.rs/compare/0.2.0...0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prima_datadog"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2018"
 description = "An opinionated library to share code and approach to Datadog logging in prima.it"
 license = "MIT"


### PR DESCRIPTION
Release prep - went for a minor version since it introduces new features

Really, I would like to un-release 0.4.0, but I'm not aware of a reasonable
way to do that
