### PR TITLE
[PLATFORM-1309]: Remove environment

### DIFF
--- a/benches/basic_incr.rs
+++ b/benches/basic_incr.rs
@@ -9,14 +9,9 @@ fn setup(_: &mut Criterion) {
     let tracker_config = TagTrackerConfiguration::new()
         .with_threshold(21)
         .with_custom_action(|_, _, _| {});
-    let configuration = PrimaConfiguration::new(
-        "0.0.0.0:1234",
-        "0.0.0.0:0",
-        "prima_datadog_benchmarks",
-        "dev".parse().unwrap(),
-    )
-    .with_country(Country::It)
-    .with_tracker_configuration(tracker_config);
+    let configuration = PrimaConfiguration::new("0.0.0.0:1234", "0.0.0.0:0", "prima_datadog_benchmarks")
+        .with_country(Country::It)
+        .with_tracker_configuration(tracker_config);
     Datadog::init(configuration).unwrap();
 }
 

--- a/src/configuration/mod.rs
+++ b/src/configuration/mod.rs
@@ -17,9 +17,6 @@ pub trait Configuration {
     fn from_addr(&self) -> &str;
     /// A namespace to prefix all metrics with, joined with a '.'.
     fn namespace(&self) -> &str;
-    /// Whether to send metrics or not.
-    /// This is useful to make the client silent in certain condition
-    fn is_reporting_enabled(&self) -> bool;
     /// Default tags to be sent with every metric reporting
     fn default_tags(&self) -> Vec<String>;
     /// if defined, will use UDS instead of UDP and will ignore UDP options
@@ -43,10 +40,6 @@ impl Configuration for dogstatsd::Options {
 
     fn namespace(&self) -> &str {
         self.namespace.as_str()
-    }
-
-    fn is_reporting_enabled(&self) -> bool {
-        true
     }
 
     fn default_tags(&self) -> Vec<String> {

--- a/src/configuration/test.rs
+++ b/src/configuration/test.rs
@@ -18,10 +18,6 @@ impl Configuration for TestConfiguration {
         "test"
     }
 
-    fn is_reporting_enabled(&self) -> bool {
-        false
-    }
-
     fn default_tags(&self) -> Vec<String> {
         vec![]
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,10 @@
 //!     "0.0.0.0:1234", // to address
 //!     "0.0.0.0:0", // from address
 //!     "service_name", // namespace for all metrics
-//!     "production".parse().unwrap() // environment
 //! );
 //!
 //! // Initializes a Datadog instance
-//! Datadog::init(configuration);
+//! Datadog::init(configuration).unwrap();
 //! ```
 //!
 //! Then you can use the macros exposed at the base level of the module.
@@ -35,9 +34,9 @@
 //! #     "0.0.0.0:1234", // to address
 //! #     "0.0.0.0:0", // from address
 //! #     "service_name", // namespace for all metrics
-//! #     "production".parse().unwrap() // environment
 //! # );
-//! # Datadog::init(configuration);
+//! # Datadog::init(configuration).unwrap();
+//!
 //! incr!("test");
 //! # incr!("test"; "some" => "data");
 //! # decr!("test");
@@ -70,9 +69,9 @@
 //! #     "0.0.0.0:1234", // to address
 //! #     "0.0.0.0:0", // from address
 //! #     "service_name", // namespace for all metrics
-//! #     "production".parse().unwrap() // environment
 //! # );
-//! # Datadog::init(configuration);
+//! # Datadog::init(configuration).unwrap();
+//!
 //! enum Metric {
 //!     John,
 //!     Paul,
@@ -105,7 +104,7 @@
 //! vary significantly. See <https://docs.datadoghq.com/getting_started/tagging/> for more information.
 //!
 //! Users may configure some actions to be taken when a metric cardinality threshold is exceeded. See
-//! [tracker::TagTrackerConfiguration] for more information.
+//! [TagTrackerConfiguration] for more information.
 //!
 //! ## References
 //!
@@ -170,9 +169,7 @@ static INSTANCE: OnceCell<Datadog<dogstatsd::Client>> = OnceCell::new();
 pub struct Datadog<C: DogstatsdClient> {
     /// an instance of a dogstatsd::Client
     inner: C,
-    /// tells if metric should be reported. If false, nothing is sent to the udp socket.
-    is_reporting_enabled: bool,
-    // Tracking for high tag cardinality
+    /// Tracking for high tag cardinality
     tag_tracker: Tracker,
 }
 
@@ -196,11 +193,7 @@ impl Datadog<dogstatsd::Client> {
             );
 
             let client: dogstatsd::Client = dogstatsd::Client::new(dogstatsd_client_options)?;
-            Ok(Self::new(
-                client,
-                configuration.is_reporting_enabled(),
-                configuration.take_tracker_config(),
-            ))
+            Ok(Self::new(client, configuration.take_tracker_config()))
         })?;
 
         if initialized {
@@ -323,40 +316,33 @@ impl Datadog<dogstatsd::Client> {
 }
 
 impl<C: DogstatsdClient> Datadog<C> {
-    fn new(client: C, is_reporting_enabled: bool, tracker_config: TagTrackerConfiguration) -> Self {
+    fn new(client: C, tracker_config: TagTrackerConfiguration) -> Self {
         Self {
             inner: client,
-            is_reporting_enabled,
             tag_tracker: tracker_config.build(),
         }
     }
 
     pub(crate) fn do_incr<S: AsRef<str>>(&self, metric: impl AsRef<str>, tags: impl TagsProvider<S>) {
-        if self.is_reporting_enabled {
-            self.inner.incr(
-                metric.as_ref(),
-                self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
-            );
-        }
+        self.inner.incr(
+            metric.as_ref(),
+            self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
+        );
     }
 
     pub(crate) fn do_decr<S: AsRef<str>>(&self, metric: impl AsRef<str>, tags: impl TagsProvider<S>) {
-        if self.is_reporting_enabled {
-            self.inner.decr(
-                metric.as_ref(),
-                self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
-            );
-        }
+        self.inner.decr(
+            metric.as_ref(),
+            self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
+        );
     }
 
     pub(crate) fn do_count<S: AsRef<str>>(&self, metric: impl AsRef<str>, count: i64, tags: impl TagsProvider<S>) {
-        if self.is_reporting_enabled {
-            self.inner.count(
-                metric.as_ref(),
-                count,
-                self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
-            );
-        }
+        self.inner.count(
+            metric.as_ref(),
+            count,
+            self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
+        );
     }
 
     pub(crate) fn do_time<S, F, O>(&self, metric: impl AsRef<str>, tags: impl TagsProvider<S>, block: F) -> O
@@ -364,15 +350,11 @@ impl<C: DogstatsdClient> Datadog<C> {
         S: AsRef<str>,
         F: FnOnce() -> O,
     {
-        if self.is_reporting_enabled {
-            self.inner.time(
-                metric.as_ref(),
-                self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
-                block,
-            )
-        } else {
-            block()
-        }
+        self.inner.time(
+            metric.as_ref(),
+            self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
+            block,
+        )
     }
 
     pub(crate) async fn do_async_time<S, F, T, O>(
@@ -386,27 +368,21 @@ impl<C: DogstatsdClient> Datadog<C> {
         F: FnOnce() -> T + Send,
         T: Future<Output = O> + Send,
     {
-        if self.is_reporting_enabled {
-            self.inner
-                .async_time(
-                    metric.as_ref(),
-                    self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
-                    block,
-                )
-                .await
-        } else {
-            block().await
-        }
+        self.inner
+            .async_time(
+                metric.as_ref(),
+                self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
+                block,
+            )
+            .await
     }
 
     pub(crate) fn do_timing<S: AsRef<str>>(&self, metric: impl AsRef<str>, ms: i64, tags: impl TagsProvider<S>) {
-        if self.is_reporting_enabled {
-            self.inner.timing(
-                metric.as_ref(),
-                ms,
-                self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
-            );
-        }
+        self.inner.timing(
+            metric.as_ref(),
+            ms,
+            self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
+        );
     }
 
     pub(crate) fn do_gauge<S: AsRef<str>>(
@@ -415,13 +391,11 @@ impl<C: DogstatsdClient> Datadog<C> {
         value: impl AsRef<str>,
         tags: impl TagsProvider<S>,
     ) {
-        if self.is_reporting_enabled {
-            self.inner.gauge(
-                metric.as_ref(),
-                value.as_ref(),
-                self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
-            );
-        }
+        self.inner.gauge(
+            metric.as_ref(),
+            value.as_ref(),
+            self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
+        );
     }
 
     pub(crate) fn do_histogram<S: AsRef<str>>(
@@ -430,13 +404,11 @@ impl<C: DogstatsdClient> Datadog<C> {
         value: impl AsRef<str>,
         tags: impl TagsProvider<S>,
     ) {
-        if self.is_reporting_enabled {
-            self.inner.histogram(
-                metric.as_ref(),
-                value.as_ref(),
-                self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
-            );
-        }
+        self.inner.histogram(
+            metric.as_ref(),
+            value.as_ref(),
+            self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
+        );
     }
 
     pub(crate) fn do_distribution<S: AsRef<str>>(
@@ -445,13 +417,11 @@ impl<C: DogstatsdClient> Datadog<C> {
         value: impl AsRef<str>,
         tags: impl TagsProvider<S>,
     ) {
-        if self.is_reporting_enabled {
-            self.inner.distribution(
-                metric.as_ref(),
-                value.as_ref(),
-                self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
-            );
-        }
+        self.inner.distribution(
+            metric.as_ref(),
+            value.as_ref(),
+            self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
+        );
     }
 
     pub(crate) fn do_set<S: AsRef<str>>(
@@ -460,13 +430,11 @@ impl<C: DogstatsdClient> Datadog<C> {
         value: impl AsRef<str>,
         tags: impl TagsProvider<S>,
     ) {
-        if self.is_reporting_enabled {
-            self.inner.set(
-                metric.as_ref(),
-                value.as_ref(),
-                self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
-            );
-        }
+        self.inner.set(
+            metric.as_ref(),
+            value.as_ref(),
+            self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
+        );
     }
 
     pub(crate) fn do_service_check<S: AsRef<str>>(
@@ -476,14 +444,12 @@ impl<C: DogstatsdClient> Datadog<C> {
         tags: impl TagsProvider<S>,
         options: Option<ServiceCheckOptions>,
     ) {
-        if self.is_reporting_enabled {
-            self.inner.service_check(
-                metric.as_ref(),
-                value,
-                self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
-                options,
-            );
-        }
+        self.inner.service_check(
+            metric.as_ref(),
+            value,
+            self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
+            options,
+        );
     }
 
     pub(crate) fn do_event<S: AsRef<str>>(
@@ -492,12 +458,10 @@ impl<C: DogstatsdClient> Datadog<C> {
         text: impl AsRef<str>,
         tags: impl TagsProvider<S>,
     ) {
-        if self.is_reporting_enabled {
-            self.inner.event(
-                metric.as_ref(),
-                text.as_ref(),
-                self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
-            );
-        }
+        self.inner.event(
+            metric.as_ref(),
+            text.as_ref(),
+            self.tag_tracker.track(&self.inner, metric.as_ref(), tags),
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! let configuration = PrimaConfiguration::new(
 //!     "0.0.0.0:1234", // to address
 //!     "0.0.0.0:0", // from address
-//!     "service_name", // namespace for all metrics
+//!     "namespace", // namespace for all metrics
 //! );
 //!
 //! // Initializes a Datadog instance
@@ -33,7 +33,7 @@
 //! # let configuration = PrimaConfiguration::new(
 //! #     "0.0.0.0:1234", // to address
 //! #     "0.0.0.0:0", // from address
-//! #     "service_name", // namespace for all metrics
+//! #     "namespace", // namespace for all metrics
 //! # );
 //! # Datadog::init(configuration).unwrap();
 //!
@@ -68,7 +68,7 @@
 //! # let configuration = PrimaConfiguration::new(
 //! #     "0.0.0.0:1234", // to address
 //! #     "0.0.0.0:0", // from address
-//! #     "service_name", // namespace for all metrics
+//! #     "namespace", // namespace for all metrics
 //! # );
 //! # Datadog::init(configuration).unwrap();
 //!

--- a/src/tests/count.rs
+++ b/src/tests/count.rs
@@ -8,29 +8,25 @@ use crate::EMPTY_TAGS;
 #[test]
 pub fn count_with_literal() {
     let mock = mocks::count_mock("test", 10, &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_count("test", 10, EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_count("test", 10, EMPTY_TAGS);
 }
 
 #[test]
 pub fn count_with_type() {
     let mock = mocks::count_mock("test1_event", 10, &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_count(TestEvent::Test1, 10, EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_count(TestEvent::Test1, 10, EMPTY_TAGS);
 }
 
 #[test]
 pub fn count_with_literal_and_tags() {
     let mock = mocks::count_mock("test", 10, &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_count("test", 10, vec!["added:tag".to_string()]);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_count("test", 10, vec!["added:tag".to_string()]);
 }
 
 #[test]
 pub fn count_with_type_and_tags() {
     let mock = mocks::count_mock("test1_event", 10, &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_count(
-        TestEvent::Test1,
-        10,
-        vec!["added:tag".to_string()],
-    );
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_count(TestEvent::Test1, 10, vec!["added:tag".to_string()]);
 }
 
 #[test]

--- a/src/tests/decr.rs
+++ b/src/tests/decr.rs
@@ -8,25 +8,25 @@ use crate::EMPTY_TAGS;
 #[test]
 pub fn decr_with_literal() {
     let mock = mocks::decr_mock("test", &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_decr("test", EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_decr("test", EMPTY_TAGS);
 }
 
 #[test]
 pub fn decr_with_type() {
     let mock = mocks::decr_mock("test1_event", &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_decr(TestEvent::Test1, EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_decr(TestEvent::Test1, EMPTY_TAGS);
 }
 
 #[test]
 pub fn decr_with_literal_and_tags() {
     let mock = mocks::decr_mock("test", &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_decr("test", vec!["added:tag".to_string()]);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_decr("test", vec!["added:tag".to_string()]);
 }
 
 #[test]
 pub fn decr_with_type_and_tags() {
     let mock = mocks::decr_mock("test1_event", &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_decr(TestEvent::Test1, vec!["added:tag".to_string()]);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_decr(TestEvent::Test1, vec!["added:tag".to_string()]);
 }
 
 #[test]

--- a/src/tests/distribution.rs
+++ b/src/tests/distribution.rs
@@ -8,23 +8,19 @@ use crate::EMPTY_TAGS;
 #[test]
 pub fn distribution_with_literal() {
     let mock = mocks::distribution_mock("test", "test_value", &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_distribution("test", "test_value", EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_distribution("test", "test_value", EMPTY_TAGS);
 }
 
 #[test]
 pub fn distribution_with_type() {
     let mock = mocks::distribution_mock("test1_event", "test_value", &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_distribution(
-        TestEvent::Test1,
-        "test_value",
-        EMPTY_TAGS,
-    );
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_distribution(TestEvent::Test1, "test_value", EMPTY_TAGS);
 }
 
 #[test]
 pub fn distribution_with_literal_and_tags() {
     let mock = mocks::distribution_mock("test", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_distribution(
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_distribution(
         "test",
         "test_value",
         vec!["added:tag".to_string()],
@@ -34,7 +30,7 @@ pub fn distribution_with_literal_and_tags() {
 #[test]
 pub fn distribution_with_type_and_tags() {
     let mock = mocks::distribution_mock("test1_event", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_distribution(
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_distribution(
         TestEvent::Test1,
         "test_value",
         vec!["added:tag".to_string()],

--- a/src/tests/event.rs
+++ b/src/tests/event.rs
@@ -8,29 +8,25 @@ use crate::EMPTY_TAGS;
 #[test]
 pub fn event_with_literal() {
     let mock = mocks::event_mock("test", "test_value", &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_event("test", "test_value", EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_event("test", "test_value", EMPTY_TAGS);
 }
 
 #[test]
 pub fn event_with_type() {
     let mock = mocks::event_mock("test1_event", "test_value", &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_event(TestEvent::Test1, "test_value", EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_event(TestEvent::Test1, "test_value", EMPTY_TAGS);
 }
 
 #[test]
 pub fn event_with_literal_and_tags() {
     let mock = mocks::event_mock("test", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_event(
-        "test",
-        "test_value",
-        vec!["added:tag".to_string()],
-    );
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_event("test", "test_value", vec!["added:tag".to_string()]);
 }
 
 #[test]
 pub fn event_with_type_and_tags() {
     let mock = mocks::event_mock("test1_event", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_event(
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_event(
         TestEvent::Test1,
         "test_value",
         vec!["added:tag".to_string()],

--- a/src/tests/gauge.rs
+++ b/src/tests/gauge.rs
@@ -8,29 +8,25 @@ use crate::EMPTY_TAGS;
 #[test]
 pub fn gauge_with_literal() {
     let mock = mocks::gauge_mock("test", "test_value", &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_gauge("test", "test_value", EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_gauge("test", "test_value", EMPTY_TAGS);
 }
 
 #[test]
 pub fn gauge_with_type() {
     let mock = mocks::gauge_mock("test1_event", "test_value", &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_gauge(TestEvent::Test1, "test_value", EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_gauge(TestEvent::Test1, "test_value", EMPTY_TAGS);
 }
 
 #[test]
 pub fn gauge_with_literal_and_tags() {
     let mock = mocks::gauge_mock("test", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_gauge(
-        "test",
-        "test_value",
-        vec!["added:tag".to_string()],
-    );
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_gauge("test", "test_value", vec!["added:tag".to_string()]);
 }
 
 #[test]
 pub fn gauge_with_type_and_tags() {
     let mock = mocks::gauge_mock("test1_event", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_gauge(
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_gauge(
         TestEvent::Test1,
         "test_value",
         vec!["added:tag".to_string()],

--- a/src/tests/histogram.rs
+++ b/src/tests/histogram.rs
@@ -8,19 +8,19 @@ use crate::EMPTY_TAGS;
 #[test]
 pub fn histogram_with_literal() {
     let mock = mocks::histogram_mock("test", "test_value", &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_histogram("test", "test_value", EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_histogram("test", "test_value", EMPTY_TAGS);
 }
 
 #[test]
 pub fn histogram_with_type() {
     let mock = mocks::histogram_mock("test1_event", "test_value", &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_histogram(TestEvent::Test1, "test_value", EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_histogram(TestEvent::Test1, "test_value", EMPTY_TAGS);
 }
 
 #[test]
 pub fn histogram_with_literal_and_tags() {
     let mock = mocks::histogram_mock("test", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_histogram(
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_histogram(
         "test",
         "test_value",
         vec!["added:tag".to_string()],
@@ -30,7 +30,7 @@ pub fn histogram_with_literal_and_tags() {
 #[test]
 pub fn histogram_with_type_and_tags() {
     let mock = mocks::histogram_mock("test1_event", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_histogram(
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_histogram(
         TestEvent::Test1,
         "test_value",
         vec!["added:tag".to_string()],

--- a/src/tests/incr.rs
+++ b/src/tests/incr.rs
@@ -8,25 +8,25 @@ use crate::EMPTY_TAGS;
 #[test]
 pub fn incr_with_literal() {
     let mock = mocks::incr_mock("test", &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_incr("test", EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_incr("test", EMPTY_TAGS);
 }
 
 #[test]
 pub fn incr_with_type() {
     let mock = mocks::incr_mock("test1_event", &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_incr(TestEvent::Test1, EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_incr(TestEvent::Test1, EMPTY_TAGS);
 }
 
 #[test]
 pub fn incr_with_literal_and_tags() {
     let mock = mocks::incr_mock("test", &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_incr("test", vec!["added:tag".to_string()]);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_incr("test", vec!["added:tag".to_string()]);
 }
 
 #[test]
 pub fn incr_with_type_and_tags() {
     let mock = mocks::incr_mock("test1_event", &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_incr(TestEvent::Test1, vec!["added:tag".to_string()]);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_incr(TestEvent::Test1, vec!["added:tag".to_string()]);
 }
 
 #[test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,4 @@
-use crate::configuration::{Environment, PrimaConfiguration};
+use crate::configuration::PrimaConfiguration;
 
 use super::*;
 
@@ -19,19 +19,9 @@ mod tracker;
 
 #[test]
 pub fn double_initialization() {
-    let datadog = Datadog::init(PrimaConfiguration::new(
-        "10.1.2.3:8125",
-        "127.0.0.1:9000",
-        "",
-        Environment::Dev,
-    ));
+    let datadog = Datadog::init(PrimaConfiguration::new("10.1.2.3:8125", "127.0.0.1:9000", ""));
     assert!(datadog.is_ok());
-    let datadog2 = Datadog::init(PrimaConfiguration::new(
-        "10.1.2.3:8125",
-        "127.0.0.1:9000",
-        "",
-        Environment::Production,
-    ));
+    let datadog2 = Datadog::init(PrimaConfiguration::new("10.1.2.3:8125", "127.0.0.1:9000", ""));
     assert!(datadog2.err().unwrap().is_once_cell_already_initialized());
 }
 

--- a/src/tests/service_check.rs
+++ b/src/tests/service_check.rs
@@ -8,7 +8,7 @@ use crate::{Datadog, ServiceCheckOptions, ServiceStatus};
 #[test]
 pub fn service_check_with_literal() {
     let mock = mocks::service_check_mock("test", ServiceStatus::OK, &[], Some(ServiceCheckOptions::default()));
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_service_check(
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_service_check(
         "test",
         ServiceStatus::OK,
         EMPTY_TAGS,
@@ -24,7 +24,7 @@ pub fn service_check_with_type() {
         &[],
         Some(ServiceCheckOptions::default()),
     );
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_service_check(
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_service_check(
         TestEvent::Test1,
         ServiceStatus::OK,
         EMPTY_TAGS,
@@ -40,7 +40,7 @@ pub fn service_check_with_literal_and_tags() {
         &["added:tag", "env:test"],
         Some(ServiceCheckOptions::default()),
     );
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_service_check(
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_service_check(
         "test",
         ServiceStatus::OK,
         vec!["added:tag".to_string()],
@@ -51,7 +51,7 @@ pub fn service_check_with_literal_and_tags() {
 #[test]
 pub fn service_check_with_type_and_tags() {
     let mock = mocks::service_check_mock("test1_event", ServiceStatus::OK, &["added:tag", "env:test"], None);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_service_check(
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_service_check(
         TestEvent::Test1,
         ServiceStatus::OK,
         vec!["added:tag".to_string()],

--- a/src/tests/set.rs
+++ b/src/tests/set.rs
@@ -8,29 +8,25 @@ use crate::EMPTY_TAGS;
 #[test]
 pub fn set_with_literal() {
     let mock = mocks::set_mock("test", "test_value", &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_set("test", "test_value", EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_set("test", "test_value", EMPTY_TAGS);
 }
 
 #[test]
 pub fn set_with_type() {
     let mock = mocks::set_mock("test1_event", "test_value", &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_set(TestEvent::Test1, "test_value", EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_set(TestEvent::Test1, "test_value", EMPTY_TAGS);
 }
 
 #[test]
 pub fn set_with_literal_and_tags() {
     let mock = mocks::set_mock("test", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_set(
-        "test",
-        "test_value",
-        vec!["added:tag".to_string()],
-    );
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_set("test", "test_value", vec!["added:tag".to_string()]);
 }
 
 #[test]
 pub fn set_with_type_and_tags() {
     let mock = mocks::set_mock("test1_event", "test_value", &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_set(
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_set(
         TestEvent::Test1,
         "test_value",
         vec!["added:tag".to_string()],

--- a/src/tests/time.rs
+++ b/src/tests/time.rs
@@ -8,29 +8,25 @@ use crate::EMPTY_TAGS;
 #[test]
 pub fn time_with_literal() {
     let mock = mocks::time_mock("test", &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_time("test", EMPTY_TAGS, || {});
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_time("test", EMPTY_TAGS, || {});
 }
 
 #[test]
 pub fn time_with_type() {
     let mock = mocks::time_mock("test1_event", &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_time(TestEvent::Test1, EMPTY_TAGS, || {});
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_time(TestEvent::Test1, EMPTY_TAGS, || {});
 }
 
 #[test]
 pub fn time_with_literal_and_tags() {
     let mock = mocks::time_mock("test", &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_time("test", vec!["added:tag".to_string()], || {});
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_time("test", vec!["added:tag".to_string()], || {});
 }
 
 #[test]
 pub fn time_with_type_and_tags() {
     let mock = mocks::time_mock("test1_event", &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_time(
-        TestEvent::Test1,
-        vec!["added:tag".to_string()],
-        || {},
-    );
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_time(TestEvent::Test1, vec!["added:tag".to_string()], || {});
 }
 
 #[test]

--- a/src/tests/timing.rs
+++ b/src/tests/timing.rs
@@ -8,29 +8,25 @@ use crate::EMPTY_TAGS;
 #[test]
 pub fn timing_with_literal() {
     let mock = mocks::timing_mock("test", 10, &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_timing("test", 10, EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_timing("test", 10, EMPTY_TAGS);
 }
 
 #[test]
 pub fn timing_with_type() {
     let mock = mocks::timing_mock("test1_event", 10, &[]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_timing(TestEvent::Test1, 10, EMPTY_TAGS);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_timing(TestEvent::Test1, 10, EMPTY_TAGS);
 }
 
 #[test]
 pub fn timing_with_literal_and_tags() {
     let mock = mocks::timing_mock("test", 10, &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_timing("test", 10, vec!["added:tag".to_string()]);
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_timing("test", 10, vec!["added:tag".to_string()]);
 }
 
 #[test]
 pub fn timing_with_type_and_tags() {
     let mock = mocks::timing_mock("test1_event", 10, &["added:tag", "env:test"]);
-    Datadog::new(mock, true, TagTrackerConfiguration::new()).do_timing(
-        TestEvent::Test1,
-        10,
-        vec!["added:tag".to_string()],
-    );
+    Datadog::new(mock, TagTrackerConfiguration::new()).do_timing(TestEvent::Test1, 10, vec!["added:tag".to_string()]);
 }
 
 #[test]

--- a/src/tests/tracker.rs
+++ b/src/tests/tracker.rs
@@ -15,7 +15,7 @@ pub fn no_actions_tracker_does_nothing() {
     for i in 0..100 {
         mock = expect_incr(mock, "test", vec![format!("{}", i)]);
     }
-    let dd = Datadog::new(mock, true, tracker_config);
+    let dd = Datadog::new(mock, tracker_config);
     for i in 0..100 {
         dd.do_incr("test", vec![format!("{}", i)]);
     }
@@ -38,7 +38,7 @@ pub fn event_action_tracker_emits_event() {
         }
         mock = expect_incr(mock, "test", vec![format!("{}", i)]);
     }
-    let dd = Datadog::new(mock, true, tracker_config);
+    let dd = Datadog::new(mock, tracker_config);
     for i in 0..100 {
         dd.do_incr("test", vec![format!("{}", i)]);
     }
@@ -69,7 +69,7 @@ fn custom_action_is_run() {
     for i in 0..100 {
         mock = expect_incr(mock, "test", vec![format!("{}", i)]);
     }
-    let dd = Datadog::new(mock, true, tracker_config);
+    let dd = Datadog::new(mock, tracker_config);
     for i in 0..100 {
         dd.do_incr("test", vec![format!("{}", i)]);
     }
@@ -93,7 +93,7 @@ pub fn check_event_sent_exactly_once() {
     let tracking_config = TagTrackerConfiguration::new()
         .with_threshold(threshold)
         .with_event(String::from(title), String::from(message));
-    let dd = Datadog::new(mock, true, tracking_config);
+    let dd = Datadog::new(mock, tracking_config);
     for i in 0..100 {
         dd.do_incr("test", vec![format!("{}", i)]);
     }
@@ -114,7 +114,7 @@ pub fn check_algorithm_counts_unique_sets_directly() {
     let tracking_config = TagTrackerConfiguration::new()
         .with_threshold(threshold)
         .with_event("title".to_string(), "text".to_string()); // This event should be emitted
-    let dd = Datadog::new(mock, true, tracking_config);
+    let dd = Datadog::new(mock, tracking_config);
     dd.do_incr("test", set1);
     dd.do_incr("test", set2);
     dd.do_incr("test", set3);

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -162,7 +162,6 @@ type ThresholdCustomAction = Box<dyn FnMut(&str, &[&str], &HashMap<String, Vec<H
 ///     "0.0.0.0:1234",
 ///     "0.0.0.0:0",
 ///     "prima_datadog_benchmarks",
-///     "dev".parse().unwrap(),
 /// ).with_country(Country::It).with_tracker_configuration(tracker_config);
 /// Datadog::init(configuration).unwrap();
 /// ```

--- a/tests/end_to_end/mod.rs
+++ b/tests/end_to_end/mod.rs
@@ -18,8 +18,7 @@ fn init_test_datadog() -> &'static UdpSocket {
     let socket = SOCKET.get_or_init(|| UdpSocket::bind("127.0.0.1:0").expect("couldn't open udp socket"));
     let address_to = format!("127.0.0.1:{}", socket.local_addr().unwrap().port());
 
-    let configuration =
-        PrimaConfiguration::new(&address_to, "0.0.0.0:0", "prova_datadog", "production".parse().unwrap());
+    let configuration = PrimaConfiguration::new(&address_to, "0.0.0.0:0", "prova_datadog");
     let _ = Datadog::init(configuration);
     socket
 }


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-1309

[BREAKING CHANGES]

Since env could be taken from "DD_ENV" it should be put optional instead of being mandatory. 

Removed QA env since it doesn't exist anymore and `is_reporting_enabled` since it is used by no one except this lib. 
