### PR TITLE
[PLATFORM-1439]: Fix tracing and metrics from audit log container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING CHANGES**:
+  - `PrimaConfiguration` is now `Config`
+  - `Config::new` now takes only 2 arguments, `to_addr` and `namespace`
+  - `from_addr` is now `0.0.0.0:0` by default, but can be customized using `.with_from_addr`
+
 ---
 
 ## [0.6.0] - 2023-10-02
@@ -19,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- **BREAKING CHANGE**: `PrimaConfiguration::new` function no longer takes `env` parameter. 
+- **BREAKING CHANGE**: `PrimaConfiguration::new` function no longer takes `env` parameter.
   - Use `with_environment` function to manually set the `env:{env}` tag
   - If no environment is set the library will use `DD_ENV` var by default if set.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
-name = "prima_datadog"
-version = "0.6.0-rc.0"
-edition = "2018"
 description = "An opinionated library to share code and approach to Datadog logging in prima.it"
+edition = "2018"
 license = "MIT"
+name = "prima_datadog"
+version = "0.7.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dogstatsd = { version = "=0.11.0", default-features = false }
-once_cell = { version = "1.9", default-features = false, features = ["std"] }
-thiserror = { version = "1.0", default-features = false }
-serde = { version = "1", optional = true }
 async-trait = "0.1"
+dogstatsd = {version = "=0.11.0", default-features = false}
+once_cell = {version = "1.9", default-features = false, features = ["std"]}
+serde = {version = "1", optional = true}
+thiserror = {version = "1.0", default-features = false}
 
 [dev-dependencies]
-mockall = { version = "0.12", default-features = false }
-serial_test = { version = "3.0.0", default-features = false }
 criterion = "0.5"
-serde_json = "1"
+mockall = {version = "0.12", default-features = false}
 rand = "0.8.5"
+serde_json = "1"
+serial_test = {version = "3.0.0", default-features = false}
 
 [[bench]]
-name = "basic_incr"
 harness = false
+name = "basic_incr"
 
 [package.metadata.docs.rs]
 # Allows us to document items as only available with certain feature flags enabled

--- a/benches/basic_incr.rs
+++ b/benches/basic_incr.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use prima_datadog::{
-    configuration::{Country, PrimaConfiguration},
+    configuration::{Config, Country},
     Datadog, TagTrackerConfiguration,
 };
 
@@ -9,7 +9,7 @@ fn setup(_: &mut Criterion) {
     let tracker_config = TagTrackerConfiguration::new()
         .with_threshold(21)
         .with_custom_action(|_, _, _| {});
-    let configuration = PrimaConfiguration::new("0.0.0.0:1234", "0.0.0.0:0", "prima_datadog_benchmarks")
+    let configuration = Config::new("0.0.0.0:1234", "prima_datadog_benchmarks")
         .with_country(Country::It)
         .with_tracker_configuration(tracker_config);
     Datadog::init(configuration).unwrap();

--- a/src/configuration/mod.rs
+++ b/src/configuration/mod.rs
@@ -3,7 +3,7 @@
 mod prima;
 mod test;
 
-pub use prima::{Country, Environment, PrimaConfiguration};
+pub use prima::{Config, Country, Environment};
 pub use test::TestConfiguration;
 
 use crate::TagTrackerConfiguration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,6 @@ pub use dogstatsd::{ServiceCheckOptions, ServiceStatus};
 use once_cell::sync::OnceCell;
 
 pub use client::DogstatsdClient;
-pub use macros::*;
 pub use tracker::*;
 
 use crate::configuration::Configuration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,15 +5,14 @@
 //! You need to call [Datadog::init] in your main binary, and to do so you'll need as argument a type that implements the [Configuration] trait.
 //! If you never call [Datadog::init] in your binary NO metrics will be sent.
 //!
-//! Inside the [configuration] you'll find an [implementation of this trait][configuration::PrimaConfiguration] tailored for prima.it needs.
+//! Inside the [configuration] you'll find an [implementation of this trait][configuration::Config] tailored for prima.it needs.
 //!
 //! ```
-//! use prima_datadog::{*, configuration::PrimaConfiguration};
+//! use prima_datadog::{*, configuration::Config};
 //!
-//! // initializes the PrimaConfiguration struct
-//! let configuration = PrimaConfiguration::new(
+//! // initializes the Config struct
+//! let configuration = Config::new(
 //!     "0.0.0.0:1234", // to address
-//!     "0.0.0.0:0", // from address
 //!     "namespace", // namespace for all metrics
 //! );
 //!
@@ -29,10 +28,9 @@
 //! - a list of tags (which is separated from the rest of the arguments by semicolon `;`) in the form of `"name" => "value"`
 //!
 //! ```
-//! # use prima_datadog::{*, configuration::PrimaConfiguration};
-//! # let configuration = PrimaConfiguration::new(
+//! # use prima_datadog::{*, configuration::Config};
+//! # let configuration = Config::new(
 //! #     "0.0.0.0:1234", // to address
-//! #     "0.0.0.0:0", // from address
 //! #     "namespace", // namespace for all metrics
 //! # );
 //! # Datadog::init(configuration).unwrap();
@@ -65,10 +63,9 @@
 //! whatever you want, as long as it implements `AsRef<str>`.
 //!
 //! ```
-//! # use prima_datadog::{*, configuration::PrimaConfiguration};
-//! # let configuration = PrimaConfiguration::new(
+//! # use prima_datadog::{*, configuration::Config};
+//! # let configuration = Config::new(
 //! #     "0.0.0.0:1234", // to address
-//! #     "0.0.0.0:0", // from address
 //! #     "namespace", // namespace for all metrics
 //! # );
 //! # Datadog::init(configuration).unwrap();

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,4 @@
-use crate::configuration::PrimaConfiguration;
+use crate::configuration::Config;
 
 use super::*;
 
@@ -19,9 +19,9 @@ mod tracker;
 
 #[test]
 pub fn double_initialization() {
-    let datadog = Datadog::init(PrimaConfiguration::new("10.1.2.3:8125", "127.0.0.1:9000", ""));
+    let datadog = Datadog::init(Config::new("10.1.2.3:8125", "127.0.0.1:9000", ""));
     assert!(datadog.is_ok());
-    let datadog2 = Datadog::init(PrimaConfiguration::new("10.1.2.3:8125", "127.0.0.1:9000", ""));
+    let datadog2 = Datadog::init(Config::new("10.1.2.3:8125", "127.0.0.1:9000", ""));
     assert!(datadog2.err().unwrap().is_once_cell_already_initialized());
 }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -19,9 +19,9 @@ mod tracker;
 
 #[test]
 pub fn double_initialization() {
-    let datadog = Datadog::init(Config::new("10.1.2.3:8125", "127.0.0.1:9000", ""));
+    let datadog = Datadog::init(Config::new("10.1.2.3:8125", "").with_from_addr("127.0.0.1:9000"));
     assert!(datadog.is_ok());
-    let datadog2 = Datadog::init(Config::new("10.1.2.3:8125", "127.0.0.1:9000", ""));
+    let datadog2 = Datadog::init(Config::new("10.1.2.3:8125", "").with_from_addr("127.0.0.1:9000"));
     assert!(datadog2.err().unwrap().is_once_cell_already_initialized());
 }
 

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -152,15 +152,14 @@ type ThresholdCustomAction = Box<dyn FnMut(&str, &[&str], &HashMap<String, Vec<H
 /// Example usage:
 /// ```rust
 /// use prima_datadog::{
-///     configuration::{Country, PrimaConfiguration},
+///     configuration::{Country, Config},
 ///     Datadog, TagTrackerConfiguration,
 /// };
 /// let tracker_config = TagTrackerConfiguration::new()
 ///     .with_threshold(21)
 ///     .with_custom_action(|_, _, _| {});
-/// let configuration = PrimaConfiguration::new(
+/// let configuration = Config::new(
 ///     "0.0.0.0:1234",
-///     "0.0.0.0:0",
 ///     "prima_datadog_benchmarks",
 /// ).with_country(Country::It).with_tracker_configuration(tracker_config);
 /// Datadog::init(configuration).unwrap();

--- a/tests/end_to_end/mod.rs
+++ b/tests/end_to_end/mod.rs
@@ -2,7 +2,7 @@ mod event;
 mod service_check;
 
 use once_cell::sync::OnceCell;
-use prima_datadog::{configuration::PrimaConfiguration, Datadog};
+use prima_datadog::{configuration::Config, Datadog};
 use std::net::UdpSocket;
 
 static SOCKET: OnceCell<UdpSocket> = OnceCell::new();
@@ -18,7 +18,7 @@ fn init_test_datadog() -> &'static UdpSocket {
     let socket = SOCKET.get_or_init(|| UdpSocket::bind("127.0.0.1:0").expect("couldn't open udp socket"));
     let address_to = format!("127.0.0.1:{}", socket.local_addr().unwrap().port());
 
-    let configuration = PrimaConfiguration::new(&address_to, "0.0.0.0:0", "prova_datadog");
+    let configuration = Config::new(&address_to, "0.0.0.0:0", "prova_datadog");
     let _ = Datadog::init(configuration);
     socket
 }

--- a/tests/end_to_end/mod.rs
+++ b/tests/end_to_end/mod.rs
@@ -18,7 +18,7 @@ fn init_test_datadog() -> &'static UdpSocket {
     let socket = SOCKET.get_or_init(|| UdpSocket::bind("127.0.0.1:0").expect("couldn't open udp socket"));
     let address_to = format!("127.0.0.1:{}", socket.local_addr().unwrap().port());
 
-    let configuration = Config::new(&address_to, "0.0.0.0:0", "prova_datadog");
+    let configuration = Config::new(&address_to, "prova_datadog");
     let _ = Datadog::init(configuration);
     socket
 }


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-1439

This PR refactors `prima_datadog.rs` so that

- `PrimaConfiguration` is simply called `Config`, since we're not really configuring Prima
- `from_addr` is optional and will be set to `0.0.0.0:0` by default

