### PR TITLE
[PLATFORM-1795]: Ensure observability is strong for migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- *Breaking*: `with_country` will now add the `prima_country` tag instead of `prima:country`
+
 ---
 
 ## [0.7.2] - 2024-05-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+---
+
+## [0.8.0] - 2024-06-21
+
 ## Changed
 
 - **Breaking**: `with_country` will now add the `prima_country` tag instead of `prima:country`
@@ -146,7 +150,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.5]
 
 
-[Unreleased]: https://github.com/primait/prima_datadog.rs/compare/0.7.2...HEAD
+
+[Unreleased]: https://github.com/primait/prima_datadog.rs/compare/0.8.0...HEAD
+[0.8.0]: https://github.com/primait/prima_datadog.rs/compare/0.7.2...0.8.0
 [0.7.2]: https://github.com/primait/prima_datadog.rs/compare/0.7.1...0.7.2
 [0.7.1]: https://github.com/primait/prima_datadog.rs/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/primait/prima_datadog.rs/compare/0.7.0...0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- *Breaking*: `with_country` will now add the `prima_country` tag instead of `prima:country`
+- **Breaking**: `with_country` will now add the `prima_country` tag instead of `prima:country`
 
 ---
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ description = "An opinionated library to share code and approach to Datadog logg
 edition = "2018"
 license = "MIT"
 name = "prima_datadog"
-version = "0.7.2"
+version = "0.8.0"
 
 [features]
 default = []

--- a/src/configuration/country.rs
+++ b/src/configuration/country.rs
@@ -82,7 +82,7 @@ mod tests {
             .with_from_addr("from_addr")
             .with_country(Country::It);
 
-        assert_eq!(config.default_tags(), vec!["prima:country:it"]);
+        assert_eq!(config.default_tags(), vec!["prima_country:it"]);
 
         let config = Configuration::new("to_addr", "namespace")
             .with_from_addr("from_addr")
@@ -90,6 +90,6 @@ mod tests {
             .with_country(Country::Es);
 
         // Datadog tag keys are allowed to map to multiple values, and I suppose we're ok with that too (e.g. cross-country infra down the line?)
-        assert_eq!(config.default_tags(), vec!["prima:country:it", "prima:country:es"]);
+        assert_eq!(config.default_tags(), vec!["prima_country:it", "prima_country:es"]);
     }
 }

--- a/src/configuration/mod.rs
+++ b/src/configuration/mod.rs
@@ -55,7 +55,7 @@ impl Configuration {
     }
 
     pub fn with_country(self, country: Country) -> Self {
-        self.with_tag("prima:country", &country)
+        self.with_tag("prima_country", &country)
     }
 
     pub fn with_tracker_configuration(mut self, tracker: TagTrackerConfiguration) -> Self {


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-1795

I noticed we still tag with `prima:country` instead of `prima_country`.

Even though the `prima_country` tag seems to be added automagically on our metrics, we should still tag them correctly. Also, `prima:country` can't be used to group metrics, only `prima_country` can.

The other option IMHO is to remove this and simply rely on the base `prima_country` tag from PlatOps

